### PR TITLE
add cloudflare SDN to whitelist

### DIFF
--- a/lists
+++ b/lists
@@ -50,7 +50,8 @@ pihole -w pubsub.plex.tv plugins.plex.tv chapterdb.plex.tv cloudfront.net \
 plex.direct csi.gstatic.com dl.opensubtitles.org speedvideo.net ton.twimg.com \
 twimg.com chapterdb.plex.tv tinyurl.com bit.ly ton.twimg.com dropbox.com \
 pubsub.plex.bz fonts.gstatic.com assets.adobedtm.com www.googletagmanager.com \
-links.services.disqus.com ump.plex.tv meta.plex.tv goo.gl
+links.services.disqus.com ump.plex.tv meta.plex.tv goo.gl \
+cdnjs.cloudflare.com
 
 pihole -b dxp.baidu.com hmma.baidu.com pasta.esfile.duapps.com \
 neweegg.net config.a-mo.net nrc.tapas.net xpu.samsungelectronics.com \
@@ -89,6 +90,8 @@ browser.pipe.aria.microsoft.com tracking.campaign-tracking-service.placelocal.co
 primoitaliablob.blob.core.windows.net srv.dc-1.net \
 wdcpeurope.microsoft.akadns.net wdcp.microsoft.akadns.net
 
+# These will block spotify ads but may break some functionality
+# on spotify mobile apps.  Use at your discretion.
 pihole -b open.spotify.com ads.converge-digital.com \
 heads-ak.spotify.com.edgesuite.net i.scdn.co audio-fac.scdn.co \
 beta.spotify.map.fastly.net spclient.wg.spotify.com \


### PR DESCRIPTION
Adding `cdnjs.cloudflare.com` to the whitelist, it's a somewhat common cloudflare SDN domain, I also added some disclaimer comments about blocking spotify as while it does block advertising it may interfere with the Spotify IOS or Android client functionality somewhat.  There are no issues with the Linux or web client however.